### PR TITLE
Adding closing </domain> tag to amd example

### DIFF
--- a/Example-XML-files/osx_amd_i440fx.xml
+++ b/Example-XML-files/osx_amd_i440fx.xml
@@ -93,3 +93,4 @@
     <qemu:env name='QEMU_ALSA_DAC_PERIOD_SIZE' value='1024'/>
     <qemu:env name='QEMU_AUDIO_TIMER_PERIOD' value='100'/>
   </qemu:commandline>
+</domain>


### PR DESCRIPTION
Hello! Here from the latest Linus tech tips video on setting up a virtualized hackintosh. I thought I'd drop in and submit a PR to fix a missing </domain> tag that they mentioned.